### PR TITLE
fix: report reasoning support from tier models instead of hardcoding false

### DIFF
--- a/extensions/provider.ts
+++ b/extensions/provider.ts
@@ -185,7 +185,7 @@ export const registerRouterProvider = (
     return {
       id: name,
       name: `Router ${name}`,
-      reasoning: false,
+      reasoning: supportsReasoning(profile, state.currentModelRegistry),
       input: ['text', 'image'] as ('text' | 'image')[],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: maxContextWindow,


### PR DESCRIPTION
Router models are registered with `reasoning: false`, which causes pi to display `think:off` in the status bar even when the router delegates to models with active reasoning (e.g. high tier → xhigh). The `supportsReasoning` helper already exists in provider.ts but was not used during model registration.

**What this changes:** Uses `supportsReasoning(profile, state.currentModelRegistry)` instead of hardcoded `false` for the `reasoning` field.

**Why it is safe:** The router already strips pi's reasoning from options before delegating:

```ts
const { reasoning: _piReasoning, ...delegationOptions } = options ?? {};
```

Setting `reasoning: true` only affects pi's display (thinking level in status bar) — not what gets sent to the LLM.

**Edge case handled:** On initial load (before `session_start`), `currentModelRegistry` is `undefined` → `supportsReasoning` returns `false` via its guard clause, preserving the existing behavior until the registry is populated on re-registration.