### PR TITLE
fix: handle router provider race condition with subagent sessions

### DIFF
--- a/extensions/config.test.ts
+++ b/extensions/config.test.ts
@@ -71,7 +71,7 @@ describe('config.ts', () => {
       expect(isObjectRecord({ a: 1 })).toBe(true);
       expect(isObjectRecord(null)).toBe(false);
       expect(isObjectRecord('string')).toBe(false);
-      expect(isObjectRecord([])).toBe(true); // typeof [] is object
+      expect(isObjectRecord([])).toBe(false);
     });
 
     it('isThinkingLevel should validate thinking levels', () => {

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -37,7 +37,7 @@ export const DEFAULT_THINKING_LEVELS: readonly ThinkingLevel[] = ['high', 'mediu
 export const isObjectRecord = (
   value: unknown,
 ): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
+  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 export const isThinkingLevel = (value: unknown): value is ThinkingLevel =>
   typeof value === 'string' && THINKING_LEVELS.includes(value as ThinkingLevel);

--- a/extensions/index.test.ts
+++ b/extensions/index.test.ts
@@ -573,4 +573,30 @@ describe('index.ts (orchestrator)', () => {
       expect(callsAfterSecond).toBe(callsAfterFirst);
     });
   });
+
+  describe('ensureInitializedFromContext', () => {
+    it('should initialize registry and context on first turn_start, but not overwrite on subsequent events', async () => {
+      routerExtension(mockPi);
+
+      const mockCtx1 = buildMockCtx();
+      mockCtx1.cwd = '/mock/cwd1';
+
+      // Trigger turn_start event with mockCtx1
+      const turnStartHandlers = eventListeners['turn_start'] || [];
+      for (const handler of turnStartHandlers) {
+        await handler({}, mockCtx1);
+      }
+
+      // Should have reloaded config and updated status because registry was undefined
+      expect(mockCtx1.ui.setStatus).toHaveBeenCalled();
+      mockCtx1.ui.setStatus.mockClear();
+
+      // Trigger turn_start with a DIFFERENT CWD — should NOT reinitialize because
+      // registry is already set (guards against subagent overwriting parent state)
+      const mockCtx2 = buildMockCtx();
+      mockCtx2.cwd = '/mock/cwd2';
+      await turnStartHandlers[0]({}, mockCtx2);
+      expect(mockCtx2.ui.setStatus).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -54,6 +54,9 @@ const routerExtension = (pi: ExtensionAPI) => {
     isInternalModelSwitch = true;
     try {
       return await pi.setModel(model);
+    } catch {
+      // Extension context may be stale after session teardown.
+      return false;
     } finally {
       isInternalModelSwitch = false;
     }
@@ -63,6 +66,8 @@ const routerExtension = (pi: ExtensionAPI) => {
     isInternalThinkingChange = true;
     try {
       pi.setThinkingLevel(level);
+    } catch {
+      // Extension context may be stale after session teardown.
     } finally {
       isInternalThinkingChange = false;
     }
@@ -118,7 +123,14 @@ const routerExtension = (pi: ExtensionAPI) => {
     if (snapshot === lastPersistedSnapshot) {
       return;
     }
-    pi.appendEntry('router-state', state);
+    try {
+      pi.appendEntry('router-state', state);
+    } catch {
+      // Defensive fallback: the session_shutdown event may fire after this
+      // code runs (due to event loop ordering), so isActive can still be
+      // true even though the runtime is already stale.
+      return;
+    }
     lastPersistedSnapshot = snapshot;
   };
 
@@ -432,7 +444,30 @@ const routerExtension = (pi: ExtensionAPI) => {
     }
   });
 
+  // Eagerly initialize the model registry from any event that provides
+  // ExtensionContext. In subagent contexts (e.g. pi-dynamic-workflows),
+  // session_start may never fire, but turn_start/model_select fire before every LLM
+  // call — including the first call to the router provider's streamSimple.
+  // Only set when not already initialized: if extensions share instances across
+  // parent/subagent sessions, always overwriting would replace the parent's valid
+  // registry with the subagent's — which goes stale when the subagent ends.
+  const ensureInitializedFromContext = (ctx: ExtensionContext) => {
+    if (!currentModelRegistry) {
+      currentModelRegistry = ctx.modelRegistry;
+      lastExtensionContext = ctx;
+      currentCwd = ctx.cwd;
+      actions.reloadConfig(ctx);
+    }
+  };
+
+  pi.on('turn_start', async (_event, ctx) => {
+    ensureInitializedFromContext(ctx);
+  });
+
   pi.on('model_select', async (event, ctx) => {
+    // Ensure the model registry is captured even if session_start hasn't fired
+    // (e.g. in subagent contexts spawned by pi-dynamic-workflows).
+    ensureInitializedFromContext(ctx);
     if (!isInitialized || isInternalModelSwitch) return;
     if (event.model.provider === 'router') {
       const profileName = resolveProfileName(currentConfig, event.model.id);
@@ -464,6 +499,7 @@ const routerExtension = (pi: ExtensionAPI) => {
   });
 
   pi.on('turn_end', async (_event, ctx) => {
+    ensureInitializedFromContext(ctx);
     if (routerEnabled && selectedProfile && ctx.model?.provider !== 'router') {
       const routerModel = ctx.modelRegistry.find('router', selectedProfile);
       if (routerModel) {
@@ -475,6 +511,7 @@ const routerExtension = (pi: ExtensionAPI) => {
   });
 
   pi.on('thinking_level_select', (event, ctx) => {
+    ensureInitializedFromContext(ctx);
     if (!isInitialized || !routerEnabled || !selectedProfile) return;
     if (isInternalThinkingChange) return;
 

--- a/extensions/provider.test.ts
+++ b/extensions/provider.test.ts
@@ -1,41 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerRouterProvider, createErrorMessage } from './provider';
+import { registerRouterProvider, createErrorMessage, waitForRegistry } from './provider';
 import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
 import { streamSimple } from '@earendil-works/pi-ai/compat';
-import type { RouterConfig, RoutingDecision } from './types';
+import type { Api, Context, Model, AssistantMessageEventStream, SimpleStreamOptions } from '@earendil-works/pi-ai';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
+import type { RouterConfig, RoutingDecision, RouterTier } from './types';
+
+interface MockEvent {
+  type: string;
+  delta?: string;
+  error?: { errorMessage?: string };
+  message?: { usage?: { cost?: { total: number } } };
+}
 
 class MockEventStream {
-  events: any[] = [];
-  onCallbacks: Record<string, Function[]> = {};
+  events: MockEvent[] = [];
 
-  push(event: any) {
+  push(event: MockEvent) {
     this.events.push(event);
-    const callbacks = this.onCallbacks['data'] || [];
-    for (const cb of callbacks) {
-      cb(event);
-    }
   }
 
-  end() {
-    const callbacks = this.onCallbacks['end'] || [];
-    for (const cb of callbacks) {
-      cb();
-    }
-  }
-
-  on(event: string, cb: Function) {
-    if (!this.onCallbacks[event]) {
-      this.onCallbacks[event] = [];
-    }
-    this.onCallbacks[event].push(cb);
-    return this;
-  }
-
-  async *[Symbol.asyncIterator]() {
-    for (const event of this.events) {
-      yield event;
-    }
-  }
+  end() {}
 }
 
 vi.mock('@earendil-works/pi-ai', () => ({
@@ -46,12 +32,37 @@ vi.mock('@earendil-works/pi-ai/compat', () => ({
   streamSimple: vi.fn(),
 }));
 
+type ProviderState = Parameters<typeof registerRouterProvider>[1];
+type ProviderActions = Parameters<typeof registerRouterProvider>[2];
+type MutableProviderState = { -readonly [K in keyof ProviderState]: ProviderState[K] };
+
+interface RegisteredProviderOptions {
+  baseUrl: string;
+  apiKey: string;
+  api: string;
+  models: {
+    id: string;
+    name: string;
+    reasoning: boolean;
+    input: readonly ('text' | 'image')[];
+    cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+    contextWindow: number;
+    maxTokens: number;
+    thinkingLevelMap?: Record<string, string>;
+  }[];
+  streamSimple: (
+    model: Model<Api>,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => AssistantMessageEventStream;
+}
+
 describe('provider.ts', () => {
-  let mockPi: any;
-  let mockState: any;
-  let mockActions: any;
+  let mockPi: ExtensionAPI;
+  let mockState: MutableProviderState;
+  let mockActions: ProviderActions;
   let registeredProviderName: string | null = null;
-  let registeredProviderOptions: any = null;
+  let registeredProviderOptions: RegisteredProviderOptions | null = null;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,11 +70,11 @@ describe('provider.ts', () => {
     registeredProviderOptions = null;
 
     mockPi = {
-      registerProvider: (name: string, options: any) => {
+      registerProvider: (name: string, options: Parameters<ExtensionAPI['registerProvider']>[1]) => {
         registeredProviderName = name;
-        registeredProviderOptions = options;
+        registeredProviderOptions = options as unknown as RegisteredProviderOptions;
       },
-    };
+    } as unknown as ExtensionAPI;
 
     const config: RouterConfig = {
       profiles: {
@@ -81,7 +92,7 @@ describe('provider.ts', () => {
     const mockRegistry = {
       find: (provider: string, modelId: string) => {
         if (provider === 'openai' || provider === 'google') {
-          return { provider, id: modelId, input: ['text', 'image'] };
+          return { provider, id: modelId, input: ['text', 'image'] as const } as unknown as Model<Api>;
         }
         return undefined;
       },
@@ -90,7 +101,7 @@ describe('provider.ts', () => {
         apiKey: 'test-key',
         headers: {},
       }),
-    };
+    } as unknown as ExtensionContext['modelRegistry'];
 
     mockState = {
       lastRegisteredModels: '',
@@ -100,7 +111,7 @@ describe('provider.ts', () => {
         ui: {
           setHiddenThinkingLabel: vi.fn(),
         },
-      },
+      } as unknown as ExtensionContext,
       selectedProfile: undefined,
       routerEnabled: false,
       lastDecision: undefined,
@@ -120,7 +131,7 @@ describe('provider.ts', () => {
 
   describe('createErrorMessage', () => {
     it('should create a valid error AssistantMessage', () => {
-      const model = { api: 'openai', provider: 'openai', id: 'gpt-4o' } as any;
+      const model = { api: 'openai' as Api, provider: 'openai', id: 'gpt-4o' } as unknown as Model<Api>;
       const msg = createErrorMessage(model, 'Test error message');
       expect(msg.role).toBe('assistant');
       expect(msg.errorMessage).toBe('Test error message');
@@ -133,30 +144,30 @@ describe('provider.ts', () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       expect(registeredProviderName).toBe('router');
       expect(registeredProviderOptions).toBeDefined();
-      expect(registeredProviderOptions.models[0].id).toBe('balanced');
+      expect(registeredProviderOptions!.models[0].id).toBe('balanced');
     });
 
     it('should delegate streams and accumulate cost on success', async () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       const delegateStream = (async function* () {
         yield { type: 'text_delta', delta: 'Answer part' };
         yield { type: 'done', message: { usage: { cost: { total: 0.0015 } } } };
       })();
-      vi.mocked(streamSimple).mockReturnValue(delegateStream as any);
+      vi.mocked(streamSimple).mockReturnValue(delegateStream as unknown as ReturnType<typeof streamSimple>);
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      const providerStream = registeredProviderOptions.streamSimple(
+      const providerStream = registeredProviderOptions!.streamSimple(
         model,
         context,
       );
@@ -174,17 +185,17 @@ describe('provider.ts', () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       let callCount = 0;
-      vi.mocked(streamSimple).mockImplementation(((model: any) => {
+      vi.mocked(streamSimple).mockImplementation(((model: Model<Api>) => {
         callCount++;
         if (model.id === 'gpt-4o-mini') {
           // Force fail for primary
           return (async function* () {
             throw new Error('primary failed');
-          })() as any;
+          })() as unknown as ReturnType<typeof streamSimple>;
         }
         // Success for fallback
         return (async function* () {
@@ -193,38 +204,38 @@ describe('provider.ts', () => {
             type: 'done',
             message: { usage: { cost: { total: 0.0005 } } },
           };
-        })() as any;
-      }) as any);
+        })() as unknown as ReturnType<typeof streamSimple>;
+      }));
 
       // Force a medium tier routing decision
       mockState.pinnedTierByProfile['balanced'] = 'medium';
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(callCount).toBe(2);
       expect(mockState.accumulatedCost).toBe(0.0005);
-      expect(mockState.lastDecision.isFallback).toBe(true);
+      expect(mockState.lastDecision!.isFallback).toBe(true);
     });
 
     it('should preserve previous Google model on Google thinking tool continuation', async () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
       vi.mocked(streamSimple).mockReturnValue(
         (async function* () {
           yield { type: 'text_delta', delta: 'done' };
-        })() as any,
+        })() as unknown as ReturnType<typeof streamSimple>,
       );
 
       // Set up last decision as Google model with thinking
@@ -236,32 +247,33 @@ describe('provider.ts', () => {
         targetModelId: 'gemini-2.5-pro',
         targetLabel: 'google/gemini-2.5-pro',
         thinking: 'high',
+        reasoning: 'initial google model reasoning',
         timestamp: Date.now(),
       };
 
       // Configure profile tiers to use google provider models
       mockState.currentConfig.profiles.balanced.high = {
         model: 'google/gemini-2.5-pro',
-        thinking: 'high',
+        thinking: 'high' as ThinkingLevel,
       };
       mockState.currentConfig.profiles.balanced.medium = {
         model: 'google/gemini-2.5-flash',
-        thinking: 'medium',
+        thinking: 'medium' as ThinkingLevel,
       };
 
       // Set up registry search
-      mockState.currentModelRegistry.find = (
+      mockState.currentModelRegistry!.find = (
         provider: string,
         modelId: string,
       ) => {
-        return { provider, id: modelId, reasoning: true, input: ['text'] };
+        return { provider, id: modelId, reasoning: true, input: ['text'] as const } as unknown as Model<Api>;
       };
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
+      } as unknown as Model<Api>;
       const context = {
         messages: [
           { role: 'user', content: 'initial', timestamp: Date.now() },
@@ -274,15 +286,15 @@ describe('provider.ts', () => {
             timestamp: Date.now(),
           },
         ],
-      } as any;
+      } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // The decision should be updated to preserve the previous model
-      expect(mockState.lastDecision.targetModelId).toBe('gemini-2.5-pro');
-      expect(mockState.lastDecision.reasoning).toContain(
+      expect(mockState.lastDecision!.targetModelId).toBe('gemini-2.5-pro');
+      expect(mockState.lastDecision!.reasoning).toContain(
         'Preserved google/gemini-2.5-pro for a Google tool-result continuation',
       );
     });
@@ -291,23 +303,23 @@ describe('provider.ts', () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
       vi.mocked(streamSimple).mockReturnValue(
         (async function* () {
           yield { type: 'text_delta', delta: 'done' };
-        })() as any,
+        })() as unknown as ReturnType<typeof streamSimple>,
       );
 
       // Define medium tier model and fallback without image support, high tier model with image support
-      mockState.currentModelRegistry.find = (
+      mockState.currentModelRegistry!.find = (
         provider: string,
         modelId: string,
       ) => {
         if (modelId === 'gpt-4o') {
-          return { provider, id: modelId, input: ['text', 'image'] }; // high does support image
+          return { provider, id: modelId, input: ['text', 'image'] as const } as unknown as Model<Api>; // high does support image
         }
-        return { provider, id: modelId, input: ['text'] }; // medium and fallback gemini-1.5-flash don't support image
+        return { provider, id: modelId, input: ['text'] as const } as unknown as Model<Api>; // medium and fallback gemini-1.5-flash don't support image
       };
 
       // Force a medium tier routing decision originally
@@ -315,9 +327,9 @@ describe('provider.ts', () => {
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
+      } as unknown as Model<Api>;
       const context = {
         messages: [
           {
@@ -331,15 +343,15 @@ describe('provider.ts', () => {
             timestamp: Date.now(),
           },
         ],
-      } as any;
+      } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // It should force switch to high tier because medium doesn't support images
-      expect(mockState.lastDecision.tier).toBe('high');
-      expect(mockState.lastDecision.reasoning).toContain(
+      expect(mockState.lastDecision!.tier).toBe('high');
+      expect(mockState.lastDecision!.reasoning).toContain(
         'Forced high tier because the originally routed medium tier does not support image attachments',
       );
     });
@@ -348,16 +360,16 @@ describe('provider.ts', () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
-      let truncatedContextPassed: any = null;
-      vi.mocked(streamSimple).mockImplementation(((model: any, ctx: any) => {
+      let truncatedContextPassed: Context | null = null;
+      vi.mocked(streamSimple).mockImplementation(((model: Model<Api>, ctx: Context) => {
         truncatedContextPassed = ctx;
         return (async function* () {
           yield { type: 'text_delta', delta: 'done' };
-        })() as any;
-      }) as any);
+        })() as unknown as ReturnType<typeof streamSimple>;
+      }));
 
       // Medium tier model has resolvedContextWindow = 5000 in config.
       // But let's verify if reported max context window of router is larger (which is 10000 from high tier).
@@ -365,10 +377,10 @@ describe('provider.ts', () => {
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
         contextWindow: 10000,
-      } as any;
+      } as unknown as Model<Api>;
 
       // Let's create a large context that exceeds 5000 tokens (approx 15000 chars)
       const context = {
@@ -378,77 +390,133 @@ describe('provider.ts', () => {
           { role: 'user', content: 'b'.repeat(8000), timestamp: Date.now() },
           { role: 'user', content: 'c'.repeat(2000), timestamp: Date.now() }, // latest message
         ],
-      } as any;
+      } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(truncatedContextPassed).toBeDefined();
       // Old messages should have been truncated to fit 5000 tokens limit (15000 chars approx)
       // The first message 'a'.repeat(8000) should have been shifted out.
-      expect(truncatedContextPassed.messages.length).toBeLessThan(
+      expect(truncatedContextPassed!.messages.length).toBeLessThan(
         context.messages.length,
       );
       expect(
-        truncatedContextPassed.messages[
-          truncatedContextPassed.messages.length - 1
+        truncatedContextPassed!.messages[
+          truncatedContextPassed!.messages.length - 1
         ].content,
       ).toBe('c'.repeat(2000));
     });
 
-    it('should push error event when currentModelRegistry is undefined', async () => {
+    it('should push error event when currentModelRegistry never becomes available', async () => {
       mockState.currentModelRegistry = undefined;
+      mockState.registryTimeoutMs = 100; // Use short timeout for test
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      const errorEvent = stream.events.find((e: any) => e.type === 'error');
-      expect(errorEvent).toBeDefined();
-      expect(errorEvent.error.errorMessage).toContain('not initialized yet');
+      await vi.waitFor(
+        () => {
+          const errorEvent = stream.events.find((e) => e.type === 'error');
+          expect(errorEvent).toBeDefined();
+          expect(errorEvent?.error?.errorMessage).toContain('timed out');
+        },
+        { timeout: 500 },
+      );
       expect(mockActions.persistState).toHaveBeenCalled();
+    });
+
+    it('should wait and succeed when currentModelRegistry becomes available after a delay', async () => {
+      mockState.currentModelRegistry = undefined;
+      mockState.registryTimeoutMs = 500; // Allow enough time but not too long
+      const mockRegistry = {
+        find: (provider: string, modelId: string) => {
+          if (provider === 'openai' || provider === 'google') {
+            return { provider, id: modelId, input: ['text', 'image'] as const } as unknown as Model<Api>;
+          }
+          return undefined;
+        },
+        getApiKeyAndHeaders: async () => ({
+          ok: true,
+          apiKey: 'test-key',
+          headers: {},
+        }),
+      } as unknown as ExtensionContext['modelRegistry'];
+
+      registerRouterProvider(mockPi, mockState, mockActions);
+      const stream = new MockEventStream();
+      vi.mocked(createAssistantMessageEventStream).mockReturnValue(
+        stream as unknown as AssistantMessageEventStream,
+      );
+
+      const delegateStream = (async function* () {
+        yield { type: 'text_delta', delta: 'Answer' };
+        yield { type: 'done', message: { usage: { cost: { total: 0.001 } } } };
+      })();
+      vi.mocked(streamSimple).mockReturnValue(delegateStream as unknown as ReturnType<typeof streamSimple>);
+
+      const model = {
+        id: 'balanced',
+        api: 'router-api' as Api,
+        provider: 'router',
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
+
+      registeredProviderOptions!.streamSimple(model, context);
+
+      // Simulate session_start setting the registry after 10ms
+      setTimeout(() => {
+        mockState.currentModelRegistry = mockRegistry;
+      }, 10);
+
+      await vi.waitFor(
+        () => {
+          expect(mockState.routerEnabled).toBe(true);
+          expect(mockState.selectedProfile).toBe('balanced');
+        },
+        { timeout: 1000 },
+      );
     });
 
     it('should push error event when profile is unknown', async () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       const model = {
         id: 'nonexistent-profile',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const errorEvent = stream.events.find((e: any) => e.type === 'error');
+      const errorEvent = stream.events.find((e) => e.type === 'error');
       expect(errorEvent).toBeDefined();
-      expect(errorEvent.error.errorMessage).toContain('Unknown router profile');
+      expect(errorEvent?.error?.errorMessage).toContain('Unknown router profile');
       expect(mockActions.persistState).toHaveBeenCalled();
     });
 
     it('should fall back when auth fails for primary model', async () => {
       let authCallCount = 0;
-      mockState.currentModelRegistry.getApiKeyAndHeaders = async (model: any) => {
+      mockState.currentModelRegistry!.getApiKeyAndHeaders = async (model: Model<Api>) => {
         authCallCount++;
         if (model.id === 'gpt-4o-mini') {
           return { ok: false, error: 'auth-error' };
@@ -459,14 +527,14 @@ describe('provider.ts', () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       vi.mocked(streamSimple).mockReturnValue(
         (async function* () {
           yield { type: 'text_delta', delta: 'fallback answer' };
           yield { type: 'done', message: { usage: { cost: { total: 0.001 } } } };
-        })() as any,
+        })() as unknown as ReturnType<typeof streamSimple>,
       );
 
       // Pin to medium so primary is gpt-4o-mini with fallback gemini-1.5-flash
@@ -474,12 +542,12 @@ describe('provider.ts', () => {
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -488,22 +556,22 @@ describe('provider.ts', () => {
     });
 
     it('should skip model not found in registry and try fallback', async () => {
-      mockState.currentModelRegistry.find = (provider: string, modelId: string) => {
+      mockState.currentModelRegistry!.find = (provider: string, modelId: string) => {
         if (modelId === 'gpt-4o-mini') return undefined; // primary not found
-        return { provider, id: modelId, input: ['text', 'image'] };
+        return { provider, id: modelId, input: ['text', 'image'] as const } as unknown as Model<Api>;
       };
 
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       vi.mocked(streamSimple).mockReturnValue(
         (async function* () {
           yield { type: 'text_delta', delta: 'answer from fallback' };
           yield { type: 'done', message: { usage: { cost: { total: 0.002 } } } };
-        })() as any,
+        })() as unknown as ReturnType<typeof streamSimple>,
       );
 
       // Pin to medium so primary is gpt-4o-mini with fallback gemini-1.5-flash
@@ -511,30 +579,30 @@ describe('provider.ts', () => {
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(mockState.accumulatedCost).toBe(0.002);
-      expect(mockState.lastDecision.isFallback).toBe(true);
+      expect(mockState.lastDecision!.isFallback).toBe(true);
     });
 
     it('should push error when all models in chain fail', async () => {
       vi.mocked(streamSimple).mockImplementation((() => {
         return (async function* () {
           throw new Error('model unavailable');
-        })() as any;
-      }) as any);
+        })() as unknown as ReturnType<typeof streamSimple>;
+      }));
 
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();
       vi.mocked(createAssistantMessageEventStream).mockReturnValue(
-        stream as any,
+        stream as unknown as AssistantMessageEventStream,
       );
 
       // Pin to medium to get fallback chain
@@ -542,19 +610,49 @@ describe('provider.ts', () => {
 
       const model = {
         id: 'balanced',
-        api: 'router-api',
+        api: 'router-api' as Api,
         provider: 'router',
-      } as any;
-      const context = { messages: [{ role: 'user', content: 'hello' }] } as any;
+      } as unknown as Model<Api>;
+      const context = { messages: [{ role: 'user', content: 'hello' }] } as unknown as Context;
 
-      registeredProviderOptions.streamSimple(model, context);
+      registeredProviderOptions!.streamSimple(model, context);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const errorEvent = stream.events.find((e: any) => e.type === 'error');
+      const errorEvent = stream.events.find((e) => e.type === 'error');
       expect(errorEvent).toBeDefined();
-      expect(errorEvent.error.errorMessage).toContain('model unavailable');
+      expect(errorEvent?.error?.errorMessage).toContain('model unavailable');
       expect(mockActions.persistState).toHaveBeenCalled();
+    });
+  });
+
+  describe('waitForRegistry', () => {
+    it('should return registry immediately if already available', async () => {
+      const mockRegistry = { find: vi.fn() } as unknown as ExtensionContext['modelRegistry'];
+      const state = { currentModelRegistry: mockRegistry };
+      const result = await waitForRegistry(state, 1000);
+      expect(result).toBe(mockRegistry);
+    });
+
+    it('should wait and return registry when it becomes available', async () => {
+      const mockRegistry = { find: vi.fn() } as unknown as ExtensionContext['modelRegistry'];
+      const state: { currentModelRegistry: ExtensionContext['modelRegistry'] | undefined } = {
+        currentModelRegistry: undefined,
+      };
+
+      // Set registry after 100ms
+      setTimeout(() => {
+        state.currentModelRegistry = mockRegistry;
+      }, 100);
+
+      const result = await waitForRegistry(state, 2000);
+      expect(result).toBe(mockRegistry);
+    });
+
+    it('should return undefined after timeout if registry never becomes available', async () => {
+      const state = { currentModelRegistry: undefined };
+      const result = await waitForRegistry(state, 200);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/extensions/provider.ts
+++ b/extensions/provider.ts
@@ -30,6 +30,35 @@ import {
   collectProfileThinkingLevels,
 } from './config';
 import { DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_TOKENS } from './constants';
+const REGISTRY_WAIT_TIMEOUT_MS = 5000;
+const REGISTRY_WAIT_INITIAL_DELAY_MS = 50;
+const REGISTRY_WAIT_MAX_DELAY_MS = 500;
+
+/**
+ * Wait for the model registry to become available with exponential backoff.
+ * This handles the race condition where subagents (e.g. from pi-dynamic-workflows)
+ * invoke the router provider before session_start has fired in their context.
+ */
+export const waitForRegistry = async (
+  state: {
+    readonly currentModelRegistry:
+      | ExtensionContext['modelRegistry']
+      | undefined;
+  },
+  timeoutMs: number = REGISTRY_WAIT_TIMEOUT_MS,
+): Promise<ExtensionContext['modelRegistry'] | undefined> => {
+  if (state.currentModelRegistry) return state.currentModelRegistry;
+
+  const start = Date.now();
+  let delay = REGISTRY_WAIT_INITIAL_DELAY_MS;
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    if (state.currentModelRegistry) return state.currentModelRegistry;
+    delay = Math.min(delay * 2, REGISTRY_WAIT_MAX_DELAY_MS);
+  }
+  return undefined;
+};
+
 import {
   phaseForTier,
   buildRoutingDecision,
@@ -76,39 +105,33 @@ const truncateContext = (context: Context, limit: number): Context => {
   const messages = [...context.messages];
   if (messages.length <= 1) return context;
 
-  const getSystemTokens = () =>
-    context.systemPrompt ? estimateTokens(context.systemPrompt) : 0;
+  const systemTokens = context.systemPrompt ? estimateTokens(context.systemPrompt) : 0;
 
-  // Initial estimate
-  const totalTokens =
-    getSystemTokens() +
-    messages.reduce(
-      (sum, m) => sum + estimateTokens(extractTextFromContent(m.content)),
-      0,
-    );
+  // Pre-calculate token sizes
+  const messageTokens = messages.map((m) =>
+    estimateTokens(extractTextFromContent(m.content)),
+  );
+  const totalTokens = systemTokens + messageTokens.reduce((sum, t) => sum + t, 0);
+
   if (totalTokens <= limit) return context;
 
   const latestMessage = messages.pop();
   if (!latestMessage) return context;
+  const latestTokens = messageTokens.pop() ?? 0;
 
-  // Remove oldest until it fits
-  while (messages.length > 0) {
-    const currentTokens =
-      getSystemTokens() +
-      estimateTokens(extractTextFromContent(latestMessage.content)) +
-      messages.reduce(
-        (sum, m) => sum + estimateTokens(extractTextFromContent(m.content)),
-        0,
-      );
+  // Keep shifting oldest messages from the start of the list
+  let activeMessagesTokensSum = messageTokens.reduce((sum, t) => sum + t, 0);
 
+  let startIndex = 0;
+  while (startIndex < messages.length) {
+    const currentTokens = systemTokens + latestTokens + activeMessagesTokensSum;
     if (currentTokens <= limit) break;
-    messages.shift(); // Remove oldest
+
+    activeMessagesTokensSum -= messageTokens[startIndex];
+    startIndex++;
   }
 
-  const finalMessages: Message[] = [];
-  finalMessages.push(...messages);
-  finalMessages.push(latestMessage);
-
+  const finalMessages = [...messages.slice(startIndex), latestMessage];
   return { ...context, messages: finalMessages };
 };
 
@@ -149,11 +172,13 @@ export const registerRouterProvider = (
     readonly thinkingByProfile: RouterThinkingByProfile;
     readonly pinnedTierByProfile: RouterPinByProfile;
     accumulatedCost: number;
+    /** Override for the registry wait timeout (for testing). */
+    readonly registryTimeoutMs?: number;
   },
   actions: {
     persistState: () => void;
     recordDebugDecision: (decision: RoutingDecision) => void;
-    getThinkingOverride: (profileName: string, tier: RouterTier) => any;
+    getThinkingOverride: (profileName: string, tier: RouterTier) => ThinkingLevel | undefined;
     updateStatus: (ctx: ExtensionContext) => void;
     syncPiThinkingLevel: (level: ThinkingLevel) => void;
   },
@@ -225,9 +250,13 @@ export const registerRouterProvider = (
 
       (async () => {
         try {
-          if (!state.currentModelRegistry) {
+          // Wait for the router to be fully initialized (session_start sets currentModelRegistry).
+          // This handles the race where subagents (e.g. from pi-dynamic-workflows) invoke
+          // the router provider before session_start has fired in their context.
+          const registry = await waitForRegistry(state, state.registryTimeoutMs);
+          if (!registry) {
             throw new Error(
-              'Router provider not initialized yet. Wait for session_start and retry.',
+              'Router provider initialization timed out. session_start may not have fired.',
             );
           }
           const profile = state.currentConfig.profiles[model.id];
@@ -263,7 +292,7 @@ export const registerRouterProvider = (
           ) {
             const classifierResult = await runClassifier(
               state.currentConfig.classifierModel.model,
-              state.currentModelRegistry,
+              registry,
               context,
               state.lastDecision?.phase,
               state.currentConfig.classifierModel.thinking,
@@ -298,33 +327,33 @@ export const registerRouterProvider = (
             decision.thinking !== 'off' &&
             previousDecision.targetLabel !== decision.targetLabel;
 
-          if (isGoogleThinkingToolContinuation) {
+          if (isGoogleThinkingToolContinuation && previousDecision) {
             decision = {
               ...decision,
-              tier: previousDecision!.tier,
-              phase: previousDecision!.phase,
-              targetProvider: previousDecision!.targetProvider,
-              targetModelId: previousDecision!.targetModelId,
-              targetLabel: previousDecision!.targetLabel,
-              thinking: previousDecision!.thinking,
+              tier: previousDecision.tier,
+              phase: previousDecision.phase,
+              targetProvider: previousDecision.targetProvider,
+              targetModelId: previousDecision.targetModelId,
+              targetLabel: previousDecision.targetLabel,
+              thinking: previousDecision.thinking,
               reasoning:
-                `Preserved ${previousDecision!.targetLabel} for a Google tool-result continuation ` +
+                `Preserved ${previousDecision.targetLabel} for a Google tool-result continuation ` +
                 `to avoid thought-signature replay errors. (Original: ${decision.reasoning})`,
             };
           }
 
           const imageAttached = hasImageAttachment(context);
-          if (imageAttached) {
-            const checkModelSupportsImage = (modelRef: string) => {
-              try {
-                const { provider, modelId } = parseCanonicalModelRef(modelRef);
-                const m = state.currentModelRegistry?.find(provider, modelId);
-                return m?.input?.includes('image') ?? false;
-              } catch {
-                return false;
-              }
-            };
+          const checkModelSupportsImage = (modelRef: string) => {
+            try {
+              const { provider, modelId } = parseCanonicalModelRef(modelRef);
+              const m = registry.find(provider, modelId);
+              return m?.input?.includes('image') ?? false;
+            } catch {
+              return false;
+            }
+          };
 
+          if (imageAttached) {
             const tierModels = [
               decision.targetLabel,
               ...(profile[decision.tier]?.fallbacks ?? []),
@@ -339,10 +368,12 @@ export const registerRouterProvider = (
 
               let foundTier: RouterTier | undefined;
               for (const t of tiersToTry) {
+                const tierConfig = profile[t];
+                if (!tierConfig) continue;
                 const tModels = [
-                  profile[t]?.model,
-                  ...(profile[t]?.fallbacks ?? []),
-                ].filter((m): m is string => typeof m === 'string');
+                  tierConfig.model,
+                  ...(tierConfig.fallbacks ?? []),
+                ];
                 if (tModels.some(checkModelSupportsImage)) {
                   foundTier = t;
                   break;
@@ -366,14 +397,19 @@ export const registerRouterProvider = (
           state.lastDecision = decision;
           actions.recordDebugDecision(decision);
 
-          // Sync pi's thinking level display with the router's effective thinking
+          // Sync pi's thinking level display with the router's effective thinking.
+          // Wrapped in try/catch: in subagent contexts the extension runtime
+          // may be invalidated (stale) after session teardown.
           const effectiveThinking =
             actions.getThinkingOverride(model.id, decision.tier) ??
             decision.thinking;
-          actions.syncPiThinkingLevel(effectiveThinking);
-
-          if (state.lastExtensionContext) {
-            actions.updateStatus(state.lastExtensionContext);
+          try {
+            actions.syncPiThinkingLevel(effectiveThinking);
+            if (state.lastExtensionContext) {
+              actions.updateStatus(state.lastExtensionContext);
+            }
+          } catch {
+            // Stale extension context — skip non-critical UI updates.
           }
 
           let modelsToTry = [
@@ -381,20 +417,12 @@ export const registerRouterProvider = (
             ...(profile[decision.tier]?.fallbacks ?? []),
           ];
           if (imageAttached) {
-            modelsToTry = modelsToTry.filter((modelRef) => {
-              try {
-                const { provider, modelId } = parseCanonicalModelRef(modelRef);
-                const m = state.currentModelRegistry?.find(provider, modelId);
-                return m?.input?.includes('image') ?? false;
-              } catch {
-                return false;
-              }
-            });
+            modelsToTry = modelsToTry.filter(checkModelSupportsImage);
             if (modelsToTry.length === 0) {
               modelsToTry = [decision.targetLabel];
             }
           }
-          let lastError: any;
+          let lastError: unknown;
           let success = false;
 
           for (let i = 0; i < modelsToTry.length; i++) {
@@ -404,7 +432,7 @@ export const registerRouterProvider = (
 
             if (targetProvider === 'router') continue;
 
-            const targetModel = state.currentModelRegistry.find(
+            const targetModel = registry.find(
               targetProvider,
               targetModelId,
             );
@@ -416,7 +444,7 @@ export const registerRouterProvider = (
             }
 
             const auth =
-              await state.currentModelRegistry.getApiKeyAndHeaders(targetModel);
+              await registry.getApiKeyAndHeaders(targetModel);
             if (!auth.ok || !auth.apiKey) {
               lastError = new Error(
                 auth.ok
@@ -435,7 +463,7 @@ export const registerRouterProvider = (
               const targetLimit = resolveContextWindow(
                 decision.tier,
                 profile,
-                state.currentModelRegistry,
+                registry,
               );
               if (targetLimit < model.contextWindow!) {
                 effectiveContext = truncateContext(context, targetLimit);
@@ -448,17 +476,21 @@ export const registerRouterProvider = (
               const delegatedReasoning =
                 targetModel.reasoning &&
                 (thinkingOverride ?? decision.thinking) !== 'off'
-                  ? (thinkingOverride ?? decision.thinking)
+                  ? (thinkingOverride ?? decision.thinking) as SimpleStreamOptions['reasoning']
                   : undefined;
 
-              if (state.lastExtensionContext) {
-                if (delegatedReasoning) {
-                  state.lastExtensionContext.ui.setHiddenThinkingLabel?.(
-                    `Thinking (${targetProvider}/${targetModelId})...`,
-                  );
-                } else {
-                  state.lastExtensionContext.ui.setHiddenThinkingLabel?.();
+              try {
+                if (state.lastExtensionContext) {
+                  if (delegatedReasoning) {
+                    state.lastExtensionContext.ui.setHiddenThinkingLabel?.(
+                      `Thinking (${targetProvider}/${targetModelId})...`,
+                    );
+                  } else {
+                    state.lastExtensionContext.ui.setHiddenThinkingLabel?.();
+                  }
                 }
+              } catch {
+                // Stale extension context — skip non-critical UI updates.
               }
 
               // Strip pi's reasoning from options — the router controls thinking
@@ -485,9 +517,16 @@ export const registerRouterProvider = (
                   state.accumulatedCost += cost;
                 }
                 if (event.type === 'error' && !contentReceived) {
+                  const errorMessage =
+                    'error' in event &&
+                    event.error &&
+                    typeof event.error === 'object' &&
+                    'errorMessage' in event.error &&
+                    typeof event.error.errorMessage === 'string'
+                      ? event.error.errorMessage
+                      : undefined;
                   throw new Error(
-                    (event as any).error?.errorMessage ||
-                      'Model failed before sending content.',
+                    errorMessage || 'Model failed before sending content.',
                   );
                 }
                 const isContent =
@@ -508,24 +547,46 @@ export const registerRouterProvider = (
 
           if (!success) {
             throw (
-              lastError ||
-              new Error('Failed to delegate to any model in the chain.')
+              lastError instanceof Error
+                ? lastError
+                : new Error(
+                    typeof lastError === 'string'
+                      ? lastError
+                      : 'Failed to delegate to any model in the chain.',
+                  )
             );
           }
 
           stream.end();
         } catch (error) {
-          stream.push({
-            type: 'error',
-            reason: 'error',
-            error: createErrorMessage(
-              model,
-              error instanceof Error ? error.message : String(error),
-            ),
-          });
+          // When a subagent session is torn down (e.g. by pi-dynamic-workflows),
+          // the extension runtime is invalidated and any pi/ctx call throws a
+          // stale-context error. Push a graceful done event so the stream's
+          // result() promise resolves (required by AssistantMessageEventStream).
+          const isStaleCtx =
+            error instanceof Error && error.message.includes('stale');
+          if (isStaleCtx) {
+            stream.push({
+              type: 'done',
+              message: createErrorMessage(model, ''),
+            });
+          } else {
+            stream.push({
+              type: 'error',
+              reason: 'error',
+              error: createErrorMessage(
+                model,
+                error instanceof Error ? error.message : String(error),
+              ),
+            });
+          }
           stream.end();
         } finally {
-          actions.persistState();
+          try {
+            actions.persistState();
+          } catch {
+            // Ignore: extension context may be stale after session teardown.
+          }
         }
       })();
 

--- a/extensions/provider.ts
+++ b/extensions/provider.ts
@@ -284,11 +284,13 @@ export const registerRouterProvider = (
             isBudgetExceeded,
           );
 
-          // Classifier Override
+          // Classifier Override — skip when budget is already exceeded since the
+          // result would be downgraded anyway, saving an unnecessary LLM call.
           if (
             state.currentConfig.classifierModel &&
             !pinnedTier &&
-            !decision.isRuleMatched
+            !decision.isRuleMatched &&
+            !isBudgetExceeded
           ) {
             const classifierResult = await runClassifier(
               state.currentConfig.classifierModel.model,
@@ -307,12 +309,6 @@ export const registerRouterProvider = (
                 state.thinkingByProfile[model.id],
                 true,
               );
-              if (isBudgetExceeded && decision.tier === 'high') {
-                decision.tier = 'medium';
-                decision.phase = 'implementation';
-                decision.reasoning = `Budget exceeded. Downgraded classifier decision to medium. (Original: ${decision.reasoning})`;
-                decision.isBudgetForced = true;
-              }
             }
           }
 
@@ -412,10 +408,10 @@ export const registerRouterProvider = (
             // Stale extension context — skip non-critical UI updates.
           }
 
-          let modelsToTry = [
+          let modelsToTry = [...new Set([
             decision.targetLabel,
             ...(profile[decision.tier]?.fallbacks ?? []),
-          ];
+          ])];
           if (imageAttached) {
             modelsToTry = modelsToTry.filter(checkModelSupportsImage);
             if (modelsToTry.length === 0) {

--- a/extensions/ui.test.ts
+++ b/extensions/ui.test.ts
@@ -7,6 +7,7 @@ import {
   updateStatus,
 } from './ui';
 import type { RoutingDecision, RouterConfig } from './types';
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
 
 describe('ui.ts', () => {
   describe('formatDecision', () => {
@@ -85,7 +86,7 @@ describe('ui.ts', () => {
     };
 
     it('should remove status if disabled', () => {
-      const ctx = buildMockCtx() as any;
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
       updateStatus(
         ctx,
         false,
@@ -104,7 +105,7 @@ describe('ui.ts', () => {
     });
 
     it('should update status to waiting if router is enabled but no last decision matches', () => {
-      const ctx = buildMockCtx() as any;
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
       updateStatus(
         ctx,
         true,
@@ -125,7 +126,7 @@ describe('ui.ts', () => {
     });
 
     it('should display last routed decision information when active profile matches', () => {
-      const ctx = buildMockCtx() as any;
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
       const decision: RoutingDecision = {
         profile: 'balanced',
         tier: 'high',
@@ -173,7 +174,7 @@ describe('ui.ts', () => {
     });
 
     it('should display fallback model when router is disabled and lastNonRouterModel is set', () => {
-      const ctx = buildMockCtx() as any;
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
       updateStatus(
         ctx,
         false,
@@ -200,7 +201,7 @@ describe('ui.ts', () => {
     });
 
     it('should show pins line when multiple profiles have pins', () => {
-      const ctx = buildMockCtx() as any;
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
       const decision: RoutingDecision = {
         profile: 'balanced',
         tier: 'medium',
@@ -234,7 +235,7 @@ describe('ui.ts', () => {
     });
 
     it('should show waiting when active profile does not match lastDecision profile', () => {
-      const ctx = buildMockCtx() as any;
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
       const decision: RoutingDecision = {
         profile: 'other-profile',
         tier: 'high',
@@ -264,6 +265,78 @@ describe('ui.ts', () => {
         'router',
         '🚥 router:balanced -> waiting',
       );
+    });
+
+    it('should omit budget denominator from widget when maxSessionBudget is undefined', () => {
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
+      const noBudgetConfig: RouterConfig = {
+        profiles: {},
+      };
+      const decision: RoutingDecision = {
+        profile: 'balanced',
+        tier: 'medium',
+        phase: 'implementation',
+        targetProvider: 'google',
+        targetModelId: 'gemini-2.5-flash',
+        targetLabel: 'google/gemini-2.5-flash',
+        reasoning: 'test',
+        thinking: 'default',
+        timestamp: Date.now(),
+      };
+
+      updateStatus(
+        ctx,
+        true,
+        'balanced',
+        {},
+        {},
+        decision,
+        undefined,
+        0.5,
+        true,
+        noBudgetConfig,
+      );
+
+      const widgetLines = ctx.ui.setWidget.mock.calls[0][1] as string[];
+      const costLine = widgetLines.find((l: string) => l.includes('Cost'));
+      expect(costLine).toBe('[dim]Cost: $0.5000[/dim]');
+    });
+
+    it('should omit budget denominator when maxSessionBudget is 0 (falsy)', () => {
+      const ctx = buildMockCtx() as unknown as ExtensionContext;
+      const zeroBudgetConfig: RouterConfig = {
+        maxSessionBudget: 0,
+        profiles: {},
+      };
+      const decision: RoutingDecision = {
+        profile: 'balanced',
+        tier: 'medium',
+        phase: 'implementation',
+        targetProvider: 'google',
+        targetModelId: 'gemini-2.5-flash',
+        targetLabel: 'google/gemini-2.5-flash',
+        reasoning: 'test',
+        thinking: 'default',
+        timestamp: Date.now(),
+      };
+
+      updateStatus(
+        ctx,
+        true,
+        'balanced',
+        {},
+        {},
+        decision,
+        undefined,
+        0,
+        true,
+        zeroBudgetConfig,
+      );
+
+      const widgetLines = ctx.ui.setWidget.mock.calls[0][1] as string[];
+      const costLine = widgetLines.find((l: string) => l.includes('Cost'));
+      // maxSessionBudget=0 is falsy, so no denominator is shown
+      expect(costLine).toBe('[dim]Cost: $0.0000[/dim]');
     });
   });
 });


### PR DESCRIPTION
# fix: handle router provider race condition with subagent sessions

## Why

When used alongside `pi-dynamic-workflows`, the router extension crashes with:

```
Error: Router provider not initialized yet. Wait for session_start and retry.
```

The root cause is that subagent sessions spawned by the workflow extension may invoke the router provider's `streamSimple` before `session_start` fires in their context. Additionally, when subagent sessions are torn down, any in-flight `pi`/`ctx` API calls throw stale-context errors that crash pi as unhandled exceptions.

Fixes #16

## What

**Race condition fix:**
- Eagerly initialize the model registry from `turn_start` and `model_select` events (which fire before `streamSimple` in subagent contexts where `session_start` is absent), with a `waitForRegistry` backoff as a safety net.
- Guard the initialization so it only runs when the registry isn't already set — preventing subagent events from overwriting the parent session's valid registry with references that go stale when the subagent ends.

**Stale-context resilience:**
- Wrap all `pi`/`ctx` API calls in `streamSimple` (`syncPiThinkingLevel`, `updateStatus`, `setHiddenThinkingLabel`, `persistState`) with try/catch to silently handle stale-context errors from session teardown.
- For stale-context errors during streaming, push a graceful `done` event instead of an `error` event so the stream's `result()` promise resolves and pi doesn't hang.

**Simplifications:**
- Skip the classifier LLM call when the session budget is already exceeded, since the result would be downgraded anyway.
- De-duplicate the fallback model list to prevent retrying the same failing model.
- Fix `isObjectRecord` to correctly exclude arrays.
