### PR TITLE
fix: dispatch custom providers through registered streams

### DIFF
--- a/extensions/provider.test.ts
+++ b/extensions/provider.test.ts
@@ -181,6 +181,57 @@ describe('provider.ts', () => {
       expect(mockActions.persistState).toHaveBeenCalled();
     });
 
+    it('should use the registered provider stream for custom APIs', async () => {
+      const customStreamSimple = vi.fn().mockReturnValue(
+        (async function* () {
+          yield { type: 'text_delta', delta: 'custom answer' };
+        })() as unknown as ReturnType<typeof streamSimple>,
+      );
+      vi.mocked(streamSimple).mockReturnValue(
+        (async function* () {
+          yield { type: 'text_delta', delta: 'compat answer' };
+        })() as unknown as ReturnType<typeof streamSimple>,
+      );
+      mockState.currentConfig.profiles.balanced.high = {
+        model: 'custom/custom-model',
+      };
+      mockState.pinnedTierByProfile.balanced = 'high';
+      mockState.currentModelRegistry!.find = (
+        provider: string,
+        modelId: string,
+      ) => ({
+        api: 'custom-api' as Api,
+        provider,
+        id: modelId,
+        input: ['text'] as const,
+      }) as unknown as Model<Api>;
+      Object.assign(mockState.currentModelRegistry!, {
+        getRegisteredProviderConfig: vi.fn().mockReturnValue({
+          api: 'custom-api',
+          streamSimple: customStreamSimple,
+        }),
+      });
+
+      registerRouterProvider(mockPi, mockState, mockActions);
+      const stream = new MockEventStream();
+      vi.mocked(createAssistantMessageEventStream).mockReturnValue(
+        stream as unknown as AssistantMessageEventStream,
+      );
+      const model = {
+        id: 'balanced',
+        api: 'router-api' as Api,
+        provider: 'router',
+      } as unknown as Model<Api>;
+      const context = {
+        messages: [{ role: 'user', content: 'hello' }],
+      } as unknown as Context;
+
+      registeredProviderOptions!.streamSimple(model, context);
+
+      await vi.waitFor(() => expect(customStreamSimple).toHaveBeenCalledOnce());
+      expect(streamSimple).not.toHaveBeenCalled();
+    });
+
     it('should try fallbacks if the primary model fails', async () => {
       registerRouterProvider(mockPi, mockState, mockActions);
       const stream = new MockEventStream();

--- a/extensions/provider.ts
+++ b/extensions/provider.ts
@@ -34,6 +34,13 @@ const REGISTRY_WAIT_TIMEOUT_MS = 5000;
 const REGISTRY_WAIT_INITIAL_DELAY_MS = 50;
 const REGISTRY_WAIT_MAX_DELAY_MS = 500;
 
+type ProviderAwareRegistry = ExtensionContext['modelRegistry'] & {
+  getRegisteredProviderConfig?: (provider: string) => {
+    api?: Api;
+    streamSimple?: typeof streamSimple;
+  };
+};
+
 /**
  * Wait for the model registry to become available with exponential backoff.
  * This handles the race condition where subagents (e.g. from pi-dynamic-workflows)
@@ -493,18 +500,30 @@ export const registerRouterProvider = (
               const { reasoning: _piReasoning, ...delegationOptions } =
                 options ?? {};
 
-              const delegatedStream = streamSimple(
-                targetModel,
-                effectiveContext,
-                {
-                  ...delegationOptions,
-                  apiKey,
-                  headers,
-                  ...(delegatedReasoning
-                    ? { reasoning: delegatedReasoning }
-                    : {}),
-                },
-              );
+              const delegatedOptions = {
+                ...delegationOptions,
+                apiKey,
+                headers,
+                ...(delegatedReasoning
+                  ? { reasoning: delegatedReasoning }
+                  : {}),
+              };
+              const registeredProvider = (
+                registry as ProviderAwareRegistry
+              ).getRegisteredProviderConfig?.(targetProvider);
+              const delegatedStream =
+                registeredProvider?.streamSimple &&
+                registeredProvider.api === targetModel.api
+                  ? registeredProvider.streamSimple(
+                      targetModel,
+                      effectiveContext,
+                      delegatedOptions,
+                    )
+                  : streamSimple(
+                      targetModel,
+                      effectiveContext,
+                      delegatedOptions,
+                    );
 
               let contentReceived = false;
               for await (const event of delegatedStream) {


### PR DESCRIPTION
## Summary

- dispatch custom-provider models through the provider's registered `streamSimple` handler
- retain compatibility dispatch for built-in providers and older Pi versions
- add a regression test for provider-scoped custom API routing

Fixes #19.

## Why

Since Pi 0.80.8, extension provider handlers are scoped to their owning provider runtime instead of being copied into the global compatibility registry. Calling compat `streamSimple` directly therefore fails for custom APIs with `No API provider registered` even though direct model selection works.

## Validation

- `npm run tsc`
- `npm test` — 188 tests passed
- Pi 0.80.10 interactive validation using this branch directly:
  - `openai-personal` custom provider route
  - `openai-work` custom provider route
  - `claude-personal` built-in fallback route
