### PR TITLE
fix: resolve credential-specific baseUrl for delegated model requests (421 on GitHub Copilot)

### DIFF
--- a/extensions/constants.ts
+++ b/extensions/constants.ts
@@ -1,3 +1,44 @@
 export const MAX_DEBUG_HISTORY = 12;
 export const DEFAULT_CONTEXT_WINDOW = 128_000;
 export const DEFAULT_MAX_TOKENS = 16_384;
+
+/**
+ * Minimal shape of `ModelRegistry.getProviderAuth()`, the resolver that
+ * surfaces a credential-specific `baseUrl` (e.g. GitHub Copilot business /
+ * enterprise tenants resolve a per-token proxy endpoint that differs from
+ * the model's static `baseUrl`). Declared locally rather than imported so
+ * the router keeps working against older `@earendil-works/pi-coding-agent`
+ * releases where this method isn't in the public type declarations yet —
+ * `resolveDelegatedModel` below feature-detects it at runtime and falls
+ * back to the model's static `baseUrl` when it's unavailable.
+ */
+export interface RegistryWithProviderAuth {
+  getProviderAuth?: (
+    provider: string,
+  ) => Promise<{ auth: { baseUrl?: string } } | undefined>;
+}
+
+/**
+ * Resolves the credential-specific `baseUrl` for a model's provider, if any,
+ * and returns a shallow-cloned model with it applied. Returns the original
+ * model unchanged when no override is available (older pi-coding-agent
+ * releases without `getProviderAuth`, no active credential, or a baseUrl
+ * that matches the model's static default already).
+ */
+export const resolveDelegatedModel = async <
+  TModel extends { provider: string; baseUrl: string },
+>(
+  registry: RegistryWithProviderAuth,
+  model: TModel,
+): Promise<TModel> => {
+  try {
+    const providerAuth = await registry.getProviderAuth?.(model.provider);
+    const authBaseUrl = providerAuth?.auth.baseUrl;
+    if (authBaseUrl && authBaseUrl !== model.baseUrl) {
+      return { ...model, baseUrl: authBaseUrl };
+    }
+  } catch {
+    // Fall back to the model's static baseUrl.
+  }
+  return model;
+};

--- a/extensions/provider.ts
+++ b/extensions/provider.ts
@@ -31,7 +31,12 @@ import {
   THINKING_LEVELS,
   clampThinkingLevel,
 } from './config';
-import { DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_TOKENS } from './constants';
+import {
+  DEFAULT_CONTEXT_WINDOW,
+  DEFAULT_MAX_TOKENS,
+  resolveDelegatedModel,
+  type RegistryWithProviderAuth,
+} from './constants';
 const REGISTRY_WAIT_TIMEOUT_MS = 5000;
 const REGISTRY_WAIT_INITIAL_DELAY_MS = 50;
 const REGISTRY_WAIT_MAX_DELAY_MS = 500;
@@ -457,6 +462,17 @@ export const registerRouterProvider = (
             const apiKey = auth.apiKey;
             const headers = auth.headers;
 
+            // getApiKeyAndHeaders() only resolves { apiKey, headers } — it does
+            // not surface a credential-specific baseUrl. Some OAuth providers
+            // (e.g. GitHub Copilot business/enterprise tenants) resolve a
+            // per-token proxy endpoint that differs from the model's static
+            // baseUrl. Without applying it here, delegated requests are sent
+            // to the wrong host and fail with 421 Misdirected Request.
+            const requestModel = await resolveDelegatedModel(
+              registry as unknown as RegistryWithProviderAuth,
+              targetModel,
+            );
+
             try {
               // HONESTY CHECK & AUTO-TRUNCATION
               // If the picked model has a smaller context than what we reported, truncate now.
@@ -510,7 +526,7 @@ export const registerRouterProvider = (
                 options ?? {};
 
               const delegatedStream = streamSimple(
-                targetModel,
+                requestModel,
                 effectiveContext,
                 {
                   ...delegationOptions,

--- a/extensions/routing.ts
+++ b/extensions/routing.ts
@@ -11,6 +11,7 @@ import type {
   RouterThinkingByTier,
 } from './types';
 import { parseCanonicalModelRef, isRouterTier } from './config';
+import { resolveDelegatedModel, type RegistryWithProviderAuth } from './constants';
 
 export const extractTextFromContent = (
   content: string | Message['content'],
@@ -403,6 +404,16 @@ export const runClassifier = async (
     const apiKey = auth.apiKey;
     const headers = auth.headers;
 
+    // getApiKeyAndHeaders() does not surface a credential-specific baseUrl.
+    // Some OAuth providers (e.g. GitHub Copilot business/enterprise tenants)
+    // resolve a per-token proxy endpoint that differs from the model's static
+    // baseUrl; without applying it, this request fails with 421 Misdirected
+    // Request.
+    const requestModel = await resolveDelegatedModel(
+      modelRegistry as unknown as RegistryWithProviderAuth,
+      model,
+    );
+
     const promptText = getLastUserText(context);
     const historyText = getRecentConversationText(context, 4);
 
@@ -437,7 +448,7 @@ ${currentPhase === 'implementation' ? 'Consider that the conversation is current
         ? thinking
         : undefined;
 
-    const stream = streamSimple(model, classifierContext, {
+    const stream = streamSimple(requestModel, classifierContext, {
       apiKey,
       headers,
       ...(reasoningOption ? { reasoning: reasoningOption } : {}),


### PR DESCRIPTION
Fixes #21.

## Problem

Delegating a turn to a `github-copilot/*` model fails with:

```
Error: OpenAI API error (421): 421 Misdirected Request
```

## Root cause

GitHub Copilot's OAuth flow resolves a **credential-specific proxy endpoint** (e.g. for business/enterprise tenants) at request time via `githubCopilotOAuth.toAuth()` in `@earendil-works/pi-ai`, which differs from the model's static `baseUrl` (`https://api.individual.githubcopilot.com`). Pi's own internal request path (`ModelRuntime.prepareRequest`) applies this override, but the router's delegation paths call `registry.getApiKeyAndHeaders(model)`, which only returns `{ apiKey, headers }` and drops `auth.baseUrl`. The delegated request is sent with the model's static (wrong) `baseUrl` and Copilot's proxy rejects it with 421.

This affects both:
- the per-turn delegation path (`provider.ts`)
- the LLM intent classifier path (`routing.ts`), which is subject to the same bug

## Fix

Added `resolveDelegatedModel()` in `constants.ts`, which resolves the credential-specific `baseUrl` via `registry.getProviderAuth(provider)` (a wrapper over `ModelRuntime.getAuth`) and applies it to the model before it's passed to `streamSimple()`. Both delegation sites now use this helper.

`getProviderAuth` is feature-detected at runtime through a small local `RegistryWithProviderAuth` interface (rather than importing the type directly), so this keeps working — falling back to the model's static `baseUrl` — against older `@earendil-works/pi-coding-agent` releases whose public `.d.ts` predates this method (verified against the currently pinned `0.80.1` devDependency, where `getProviderAuth` isn't yet declared).

## Testing

- `npm run tsc` — no new errors (two pre-existing, unrelated `"max"` thinking-level errors remain, present on `main` too)
- `npm test` — 187/187 passing, unchanged
- `npx prettier --check` on touched files — clean
- Manually verified against a live `github-copilot` OAuth session with an `auto` profile routing to Copilot models: 421 reproduced on `main`, resolved with this patch
